### PR TITLE
Porting to Spring 4.3.8.

### DIFF
--- a/fp/spring-elapsed/pom.xml
+++ b/fp/spring-elapsed/pom.xml
@@ -4,9 +4,9 @@
   <groupId>dojokaffe.fp.aop</groupId>
   <name>Spring AOP example</name>
   <artifactId>elapsed-aop</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
   <properties>
-    <spring.version>3.0.5.RELEASE</spring.version>
+    <spring.version>4.3.8.RELEASE</spring.version>
   </properties>
   <dependencies>
     <dependency>
@@ -40,4 +40,19 @@
       <version>2.2</version>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>dojokaffe.fp.aop.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/fp/spring-elapsed/src/main/resources/elapsed-context.xml
+++ b/fp/spring-elapsed/src/main/resources/elapsed-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.3.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 <bean id="task" class="dojokaffe.fp.aop.MonitoredTask"></bean>


### PR DESCRIPTION
Ok, refresh a bit this stuff.
Is still necessary to run it from eclipse, since dependencies are not downloaded or integrated in final jar.